### PR TITLE
Add configuration file handling and move stat method and version there

### DIFF
--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -30,6 +30,14 @@ def _read_config_file(storage_type):
     return cfg
 
 
+def _extract_method(method):
+   """Extract functional method from string. Works like eval but more secure."""
+   if method.split(".")[0] == "np" or method.split(".")[0] == "numpy":
+       return getattr(np, method.split(".")[1])
+   else:
+       raise ValueError(f"Could not recognize {method} as permitted.")
+
+
 class Active:
     """ 
     Instantiates an interface to active storage which contains either zarr files
@@ -169,7 +177,7 @@ class Active:
         """
         method = self._methods.get(self._method, None)
         if method:
-            return eval(method)
+            return _extract_method(method)
 
     @method.setter
     def method(self, value):

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -33,7 +33,11 @@ def _read_config_file(storage_type):
 def _extract_method(method):
    """Extract functional method from string. Works like eval but more secure."""
    if method.split(".")[0] == "np" or method.split(".")[0] == "numpy":
-       return getattr(np, method.split(".")[1])
+       try:
+           func = getattr(np, method.split(".")[1])
+           return func
+       except AttributeError:
+           raise AttributeError(f"Method {method} is not a valid Numpy method.")
    else:
        raise ValueError(f"Could not recognize {method} as permitted.")
 

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -39,7 +39,7 @@ def _extract_method(method):
        except AttributeError:
            raise AttributeError(f"Method {method} is not a valid Numpy method.")
    else:
-       raise ValueError(f"Could not recognize {method} as permitted.")
+       raise ValueError(f"Could not recognize method {method} as permitted.")
 
 
 class Active:

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -21,6 +21,8 @@ def _read_config_file(storage_type):
         config_file = base_path / Path("config-s3-storage.yml")
     elif storage_type == "Posix":
         config_file = base_path / Path("config-Posix-storage.yml")
+    else:
+        raise ValueError(f"Storage type {storage_type} not known.")
     if not config_file.exists():
         raise IOError(f'Config file `{config_file}` does not exist.')
 

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -23,8 +23,9 @@ def _read_config_file(storage_type):
         config_file = base_path / Path("config-Posix-storage.yml")
     else:
         raise ValueError(f"Storage type {storage_type} not known.")
-    if not config_file.exists():
-        raise IOError(f'Config file `{config_file}` does not exist.')
+    # should not need this if conf file is at package-level
+    # if not config_file.exists():
+    #     raise IOError(f'Config file `{config_file}` does not exist.')
 
     with open(config_file, 'r') as file:
         cfg = yaml.safe_load(file)
@@ -84,8 +85,9 @@ class Active:
         # read methods version, components
         self._version = self._config.get("version", 1)
         self._methods = self._config.get("methods", None)
-        if not self._methods:
-            raise ValueError(f"Configuration dict {self._config} needs a valid methods group.")
+        # should not need this if conf file is at package-level
+        # if not self._methods:
+        #     raise ValueError(f"Configuration dict {self._config} needs a valid methods group.")
         self._components = False
         self._method = None
        

--- a/activestorage/config-Posix-storage.yml
+++ b/activestorage/config-Posix-storage.yml
@@ -1,0 +1,1 @@
+version: 1

--- a/activestorage/config-Posix-storage.yml
+++ b/activestorage/config-Posix-storage.yml
@@ -1,1 +1,6 @@
 version: 1
+methods:
+  min: np.min
+  max: np.max
+  sum: np.sum
+  mean: np.sum

--- a/activestorage/config-s3-storage.yml
+++ b/activestorage/config-s3-storage.yml
@@ -1,0 +1,1 @@
+version: 1

--- a/activestorage/config-s3-storage.yml
+++ b/activestorage/config-s3-storage.yml
@@ -1,1 +1,6 @@
 version: 1
+methods:
+  min: min
+  max: max
+  sum: dimsum
+  mean: mean

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,7 @@
 import activestorage
 
 from activestorage import Active as act
+from activestorage.active import _read_config_file as read_conf
 
 
 # test version
@@ -29,3 +30,19 @@ def test_active_class_attrs():
     assert hasattr(act, "components")
     assert hasattr(act, "method")
     assert hasattr(act, "ncvar")
+
+
+# check validity of conf files
+def test_read_config_file():
+    """Test validity of package-level files."""
+    posix_mandatory_keys = ["version", "methods"]
+    s3_mandatory_keys = ["version", "methods"]
+    posix_file = read_conf("Posix")
+    s3_file = read_conf("S3")
+    print(posix_file)
+    print(s3_file)
+    for mandatory_key in posix_mandatory_keys:
+        assert mandatory_key in posix_file
+    for mandatory_key in s3_mandatory_keys:
+        assert mandatory_key in s3_file
+    

--- a/tests/unit/test_active.py
+++ b/tests/unit/test_active.py
@@ -83,3 +83,23 @@ def test_active():
     init = active.__init__(uri=uri, ncvar=ncvar, missing_value=True,
                            fill_value=1e20, valid_min=-1,
                            valid_max=1200)
+
+
+def test_config_s3():
+    uri = "tests/test_data/cesm2_native.nc"
+    ncvar = "TREFHT"
+    active = Active(uri, ncvar=ncvar, storage_type="S3")
+    assert active._methods == {'max': 'max', 'mean': 'mean',
+                               'min': 'min', 'sum': 'dimsum'}
+    assert active.method is None
+    assert active._version == 1
+
+
+def test_config_Posix():
+    uri = "tests/test_data/cesm2_native.nc"
+    ncvar = "TREFHT"
+    active = Active(uri, ncvar=ncvar, storage_type="Posix")
+    assert active._methods == {'max': 'np.max', 'mean': 'np.sum',
+                               'min': 'np.min', 'sum': 'np.sum'}
+    assert active.method is None
+    assert active._version == 1

--- a/tests/unit/test_active.py
+++ b/tests/unit/test_active.py
@@ -94,6 +94,19 @@ def test_config_s3():
     assert active.method is None
     assert active._version == 1
 
+    active._version = 2
+
+    # statistical method can not be executed
+    active.method = "mean"
+    with pytest.raises(ValueError) as exc:
+        active[:]
+    assert str(exc.value) == "Could not recognize method mean as permitted."
+
+    # bad name for statistical method
+    with pytest.raises(ValueError) as exc:
+        active.method = "meany"
+    assert str(exc.value) == "Bad 'method': meany. Choose from min/max/mean/sum."
+
 
 def test_config_Posix():
     uri = "tests/test_data/cesm2_native.nc"
@@ -103,3 +116,23 @@ def test_config_Posix():
                                'min': 'np.min', 'sum': 'np.sum'}
     assert active.method is None
     assert active._version == 1
+
+    active._version = 2
+
+    # usual run
+    active.method = "mean"  # will exec np.mean from config
+    assert active[:] == 284.22694905598956
+
+    # passing wrong numpy method
+    active._methods["mean"] = "np.meany"
+    with pytest.raises(AttributeError) as exc:
+        active[:]
+    assert str(exc.value) == "Method np.meany is not a valid Numpy method."
+
+
+def test_config_invalid_storage_type():
+    uri = "tests/test_data/cesm2_native.nc"
+    ncvar = "TREFHT"
+    with pytest.raises(ValueError) as exc:
+        Active(uri, ncvar=ncvar, storage_type="cowabunga")
+    assert str(exc.value) == "Storage type cowabunga not known."


### PR DESCRIPTION
Closes #34 

### Description

- I added two yaml configuration files, one for Posix, another for S3;
- loading of each file is done via a kwarg `storage_type` passed to `Active` class
- these files are very basic so far: just "version" and "methods" keys so far; the methods actually work fine for Posix ->
- the `method` is picked up from the `methods` key in the config and converted to an actual Python method
- version works fine too