### PR TITLE
add newly regenerated codecov token

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+codecov: 
+  token: 562143a4-8321-437a-bb94-a4c4a5455a1a
 coverage:
   status:
     project: off


### PR DESCRIPTION
Trying to restart codecov coverage markers after we moved from my private repo.