### PR TITLE
Add Wacasoft Reductionist server and use it for tests

### DIFF
--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -616,7 +616,7 @@ class Active:
                 # special case for "anon=True" buckets that work only with e.g.
                 # fs = s3fs.S3FileSystem(anon=True, client_kwargs={'endpoint_url': S3_URL})
                 # where file uri = bucketX/fileY.mc
-                print("S3 Storage options to Reductionist:", self.storage_options)
+                # print("S3 Storage options to Reductionist:", self.storage_options)
                 if self.storage_options.get("anon", None) == True:
                     bucket = os.path.dirname(parsed_url.path)  # bucketX
                     object = os.path.basename(parsed_url.path)  # fileY
@@ -650,7 +650,7 @@ class Active:
 
             # Reductionist returns "count" as a list even for single elements
             tmp, count = reductionist.reduce_chunk(session,
-                                                   "https://192.171.169.113:8080",
+                                                   "https://reductionist.jasmin.ac.uk/",  # Wacasoft
                                                    self.filename,
                                                    bucket, self.filename, offset,
                                                    size, compressor, filters,

--- a/tests/test_real_s3.py
+++ b/tests/test_real_s3.py
@@ -16,7 +16,8 @@ def test_s3_dataset():
         'secret': "$/'#M{0{/4rVhp%n^(XeX$q@y#&(NM3W1->~N.Q6VP.5[@bLpi='nt]AfH)>78pT",
         'client_kwargs': {'endpoint_url': "https://uor-aces-o.s3-ext.jc.rl.ac.uk"},
     }
-    active_storage_url = "https://192.171.169.113:8080"
+    # active_storage_url = "https://192.171.169.113:8080"  # Bryan VM
+    active_storage_url = "https://reductionist.jasmin.ac.uk/"  # Wacasoft
     # bigger_file = "ch330a.pc19790301-bnl.nc"  # 18GB 3400 HDF5 chunks
     bigger_file = "ch330a.pc19790301-def.nc"  # 17GB 64 HDF5 chunks
     # bigger_file = "da193a_25_day__198808-198808.nc"  # 3GB 30 HDF5 chunks


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

We should have the Wacasoft Reductionist be used in the tests.


## Before you get started

- ~[ ] [☝ Create an issue](https://github.com/valeriupredoi/PyActiveStorage/issues) to discuss what you are going to do~

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- ~[ ] Any changed dependencies have been added or removed correctly (if need be)~
- [x] All tests pass
