### PR TITLE
`fill_value` handling has changed in numpy=2.4.0

### DIFF
--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -114,6 +114,8 @@ def get_missing_attributes(ds):
 
     _FillValue = hfix(ds.attrs.get('_FillValue'))
     missing_value = ds.attrs.get('missing_value')
+    if isinstance(missing_value, np.ndarray):
+        missing_value = missing_value[0]
     valid_min = hfix(ds.attrs.get('valid_min'))
     valid_max = hfix(ds.attrs.get('valid_max'))
     valid_range = hfix(ds.attrs.get('valid_range'))

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -114,6 +114,7 @@ def get_missing_attributes(ds):
 
     _FillValue = hfix(ds.attrs.get('_FillValue'))
     missing_value = ds.attrs.get('missing_value')
+    # see https://github.com/NCAS-CMS/PyActiveStorage/pull/303
     if isinstance(missing_value, np.ndarray):
         missing_value = missing_value[0]
     valid_min = hfix(ds.attrs.get('valid_min'))

--- a/tests/unit/test_active.py
+++ b/tests/unit/test_active.py
@@ -8,7 +8,7 @@ from botocore.exceptions import EndpointConnectionError as botoExc
 from botocore.exceptions import NoCredentialsError as NoCredsExc
 from netCDF4 import Dataset
 
-from activestorage.active import Active, load_from_s3
+from activestorage.active import Active, load_from_s3, get_missing_attributes
 from activestorage.config import *
 
 
@@ -30,6 +30,13 @@ def test_uri_nonexistent():
     with pytest.raises(ValueError) as exc:
         active = Active(some_file, ncvar="")
     assert str(exc.value) == expected
+
+
+def test_get_missing_attributes():
+    """Test get missing attributes."""
+    ds = pyfive.File("tests/test_data/cesm2_native.nc")["TREFHT"]
+    missing_attrs = get_missing_attributes(ds)
+    assert missing_attrs == (np.float32(-900.0), np.float32(-900.0), None, None)
 
 
 def test_getitem():


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


In numpy=2.4.0 a one-element np.ndarray missing_value is not accepted anymore once the fill_value is a float, and tosses a ValueError: setting an element with a sequence, and as of https://github.com/numpy/numpy/issues/29421 and https://github.com/numpy/numpy/pull/29423 it only accepts floats and strings. This comes from a now-enforced Deprecation that allows only 0-dim arrays to be converted to scalars:

`TypeError: only 0-dimensional arrays can be converted to Python scalars`

See https://github.com/numpy/numpy/issues/30591

The MRE I posted at numpy:

```python
import numpy as np


# works fine
missing_value = 33.
data = np.ma.array(
    [[[-900., 33.], [33., -900], [33., 44.]]],
    mask=False,
    fill_value=-900.0,
    dtype=float
)
s = np.ma.masked_equal(data, missing_value)
print(s)

# fails only with numpy=2.4.0
missing_value = np.array([33.], dtype=float)
data = np.ma.array(
    [[[-900., 33.], [33., -900], [33., 44.]]],
    mask=False,
    fill_value=-900.0,
    dtype=float
)
s = np.ma.masked_equal(data, missing_value)
print(s)
```


## Before you get started

- [ ] [☝ Create an issue](https://github.com/valeriupredoi/PyActiveStorage/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] All tests pass
