### PR TITLE
[DNM][Test CEDA NGINX] Reduce maxthreads

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - reduce_maxthreads
   schedule:
     - cron: '0 0 * * *'  # nightly
 
@@ -36,7 +37,7 @@ jobs:
       - run: conda list
       - run: pip install -e .
       - run: conda list
-      - run: pytest -n 2
+      - run: pytest -n 2 tests/test_real_https.py
 
   osx:
     runs-on: "macos-latest"
@@ -61,4 +62,4 @@ jobs:
       - run: conda list
       - run: mamba install -c conda-forge git
       - run: pip install -e .
-      - run: pytest -n 2
+      - run: pytest -n 2 tests/test_real_https.py

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -189,7 +189,7 @@ class Active:
                  ncvar: str = None,
                  axis: tuple = None,
                  interface_type: str = None,
-                 max_threads: int = 20,
+                 max_threads: int = 40,
                  storage_options: dict = None,
                  active_storage_url: str = None,
                  option_disable_chunk_cache: bool = False) -> None:

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -189,7 +189,7 @@ class Active:
                  ncvar: str = None,
                  axis: tuple = None,
                  interface_type: str = None,
-                 max_threads: int = 10,
+                 max_threads: int = 20,
                  storage_options: dict = None,
                  active_storage_url: str = None,
                  option_disable_chunk_cache: bool = False) -> None:

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -189,7 +189,7 @@ class Active:
                  ncvar: str = None,
                  axis: tuple = None,
                  interface_type: str = None,
-                 max_threads: int = 100,
+                 max_threads: int = 10,
                  storage_options: dict = None,
                  active_storage_url: str = None,
                  option_disable_chunk_cache: bool = False) -> None:

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -189,7 +189,7 @@ class Active:
                  ncvar: str = None,
                  axis: tuple = None,
                  interface_type: str = None,
-                 max_threads: int = 100,
+                 max_threads: int = 60,
                  storage_options: dict = None,
                  active_storage_url: str = None,
                  option_disable_chunk_cache: bool = False) -> None:

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -189,7 +189,7 @@ class Active:
                  ncvar: str = None,
                  axis: tuple = None,
                  interface_type: str = None,
-                 max_threads: int = 40,
+                 max_threads: int = 100,
                  storage_options: dict = None,
                  active_storage_url: str = None,
                  option_disable_chunk_cache: bool = False) -> None:


### PR DESCRIPTION
### Mapping the CEDA NGINX threaded concurrency issue

See GHA https://github.com/NCAS-CMS/PyActiveStorage/actions/runs/26487146543 (see right hand tab that records reruns: click Latest batch 4 to open the list of previous (re-)runs): full run 10 jobs running GETS on the same files on NGINX store, 100 max threads/requests/file (this is, of course, theoretical, we only request 100 threads, in practice, it's a fair fewer that get sent):

#### 100 maxthreads
(10-13min for `pytest -n 2 tests/test_real_https.py`)

- Attempt 1: 10 concurrent jobs (1,000 requests/file):  6 fails
- Attempt 2:  6 concurrent jobs  (600 requests/file):   4 fails
- Attempt 3:  4 concurrent jobs  (400 requests/file):   2 fails
- Attempt 4:  2 concurrent jobs  (200 requests/file):   2 fails
- Attempt 5: 20 concurrent jobs (2,000 requests/file): 18 fails

#### Reducing maxthreads to 10

(10-13min for `pytest -n 2 tests/test_real_https.py`)
- Attempt 1: 12 concurrent jobs (120 requests/file):    0 fails
- Attempt 2: 10 concurrent jobs (100 requests/file):    0 fails

#### Upping maxthreads to 20
(8-11min for `pytest -n 2 tests/test_real_https.py`)

- Attempt 1: 12 concurrent jobs (240 requests/file):    0 fails

#### Upping maxthreads to 40
(8-9 min for `pytest -n 2 tests/test_real_https.py`)

- Attempt 1: 12 concurrent jobs (480 requests/file):    1 fails

#### Upping maxthreads to 60
(9-11 min for `pytest -n 2 tests/test_real_https.py`)

- Attempt 1: 12 concurrent jobs (720 requests/file):    6 fails

The CEDA NGINX storage is starting to show signs of failure around 400 odd concurrent GETs per file, whereas the DKRZ storage is a lot more resilient starting to crumble at 2-3x the number of GETs per file. That said, we using anything more than `max_threads = 30` is probably overkill from a number of points: file chunking should be a lot coarser, effective Python threads can't be gained after 30 odd, and, above all, we can always make `max_threads` an `Active` parameter.

Varsiha's test script from #333 shows the same behaviour  - things starting to cook up at around 50 threads, at 100 things are completely broken; see https://github.com/NCAS-CMS/PyActiveStorage/actions/runs/26521834459

attn: @varsiha-sothilingam @bnlawrence 